### PR TITLE
Use web crypto tokens for admin auth

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  if (!isAuthenticated()) {
+  if (!(await isAuthenticated())) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   const data = await request.json();

--- a/app/api/galleries/route.ts
+++ b/app/api/galleries/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  if (!isAuthenticated()) {
+  if (!(await isAuthenticated())) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   const data = await request.json();

--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -5,7 +5,8 @@ export async function POST(request: Request) {
   const { username, password } = await request.json();
   if (await verifyUser(username, password)) {
     const res = NextResponse.json({ ok: true });
-    res.cookies.set('user', createToken(username), { httpOnly: true, sameSite: 'lax', path: '/' });
+    const token = await createToken(username);
+    res.cookies.set('user', token, { httpOnly: true, sameSite: 'lax', path: '/' });
     return res;
   }
   return NextResponse.json({ ok: false }, { status: 401 });

--- a/app/api/promos/route.ts
+++ b/app/api/promos/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  if (!isAuthenticated()) {
+  if (!(await isAuthenticated())) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   const data = await request.json();

--- a/app/api/staff/route.ts
+++ b/app/api/staff/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  if (!isAuthenticated()) {
+  if (!(await isAuthenticated())) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   const data = await request.json();

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -1,0 +1,57 @@
+const SECRET = process.env.AUTH_SECRET || 'dev-secret';
+const encoder = new TextEncoder();
+
+let keyPromise: Promise<CryptoKey> | undefined;
+
+function bufferToHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function hexToBytes(hex: string): ArrayBuffer {
+  if (hex.length % 2 !== 0) {
+    throw new Error('Invalid hex string');
+  }
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes.buffer;
+}
+
+async function getKey() {
+  if (!globalThis.crypto?.subtle) {
+    throw new Error('Web Crypto API not available');
+  }
+  if (!keyPromise) {
+    keyPromise = globalThis.crypto.subtle.importKey(
+      'raw',
+      encoder.encode(SECRET),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['sign', 'verify'],
+    );
+  }
+  return keyPromise;
+}
+
+export async function createToken(username: string) {
+  const key = await getKey();
+  const signature = await globalThis.crypto.subtle.sign('HMAC', key, encoder.encode(username));
+  return `${username}.${bufferToHex(signature)}`;
+}
+
+export async function verifyToken(token: string): Promise<string | null> {
+  const [name, signature] = token.split('.');
+  if (!name || !signature) return null;
+  const key = await getKey();
+  const signatureBytes = hexToBytes(signature);
+  const isValid = await globalThis.crypto.subtle.verify(
+    'HMAC',
+    key,
+    signatureBytes,
+    encoder.encode(name),
+  );
+  return isValid ? name : null;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { verifyToken } from '@/lib/auth';
+import { verifyToken } from '@/lib/token';
 
-export function middleware(req: NextRequest) {
+export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
   if (pathname.startsWith('/admin') && pathname !== '/admin/login') {
     const token = req.cookies.get('user')?.value;
-    if (!token || !verifyToken(token)) {
+    if (!token || !(await verifyToken(token))) {
       return NextResponse.redirect(new URL('/admin/login', req.url));
     }
   }


### PR DESCRIPTION
## Summary
- add a Web Crypto-based token helper and switch the middleware to use it so admin auth works under `next start`
- update the server auth utilities to be async-aware and reuse the new token helper
- await the auth check in admin data APIs and wait for the token before setting the login cookie

## Testing
- npm run build
- npm run start
- curl -I http://localhost:3000/admin
- curl -I http://localhost:3000/admin/login

------
https://chatgpt.com/codex/tasks/task_e_68c98a3a36748327a35bd7214ffd0140