### PR TITLE
Allow admin login path variants to bypass auth middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -4,7 +4,7 @@ import { verifyToken } from '@/lib/auth';
 
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
-  if (pathname.startsWith('/admin') && pathname !== '/admin/login') {
+  if (pathname.startsWith('/admin') && !pathname.startsWith('/admin/login')) {
     const token = req.cookies.get('user')?.value;
     if (!token || !verifyToken(token)) {
       return NextResponse.redirect(new URL('/admin/login', req.url));


### PR DESCRIPTION
## Summary
- update admin middleware to exempt any /admin/login path variants from authentication

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c98a427b3c8327942a1e7ea223c58f