### PR TITLE
Add admin login integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node --test"
+    "test": "node --test --loader ./tests/alias-loader.mjs"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { NextRequest } from 'next/server.js';
+import { POST as loginHandler } from '../app/api/login/route.ts';
+import { middleware } from '../middleware.ts';
+
+test('authenticated users can load the admin page', async () => {
+  const loginRequest = new Request('http://localhost/api/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ username: 'admin', password: 'password' }),
+  });
+
+  const loginResponse = await loginHandler(loginRequest);
+  assert.equal(loginResponse.status, 200, 'login should succeed with valid credentials');
+
+  const cookie = loginResponse.cookies.get('user');
+  assert.ok(cookie?.value, 'login response should set the session cookie');
+
+  const adminRequest = new NextRequest('http://localhost/admin', {
+    headers: { cookie: `user=${cookie.value}` },
+  });
+
+  const adminResponse = middleware(adminRequest);
+  assert.ok(adminResponse, 'middleware should return a response');
+  assert.equal(adminResponse.status, 200, 'admin access should be allowed when authenticated');
+});

--- a/tests/alias-loader.mjs
+++ b/tests/alias-loader.mjs
@@ -1,0 +1,36 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const projectRoot = process.cwd();
+
+export async function resolve(specifier, context, defaultResolve) {
+  if (specifier === 'next/server') {
+    return defaultResolve('next/server.js', context, defaultResolve);
+  }
+
+  if (specifier === 'next/headers') {
+    return defaultResolve('next/headers.js', context, defaultResolve);
+  }
+
+  if (specifier.startsWith('@/')) {
+    const relativePath = specifier.slice(2);
+    const absolutePath = path.join(projectRoot, relativePath);
+
+    const candidatePaths = [
+      absolutePath,
+      `${absolutePath}.ts`,
+      `${absolutePath}.tsx`,
+      path.join(absolutePath, 'index.ts'),
+      path.join(absolutePath, 'index.tsx'),
+    ];
+
+    for (const candidate of candidatePaths) {
+      if (fs.existsSync(candidate)) {
+        const url = pathToFileURL(candidate).href;
+        return defaultResolve(url, context, defaultResolve);
+      }
+    }
+  }
+  return defaultResolve(specifier, context, defaultResolve);
+}


### PR DESCRIPTION
## Summary
- add a node:test suite that verifies a successful login issues a session cookie and unlocks the admin route
- introduce a custom loader so node --test can resolve Next.js aliases when running the suite
- update the npm test script to register the loader automatically

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c98a463d0c8327bc3f2f381cd9794f