### PR TITLE
Include credentials when logging in

### DIFF
--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -16,6 +16,7 @@ export default function LoginPage() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password }),
+      credentials: 'include',
     });
     if (res.ok) {
       router.push('/admin');


### PR DESCRIPTION
## Summary
- add `credentials: 'include'` to the admin login request so the session cookie is saved

## Testing
- npm test *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/workspace/ywi-nextjs/lib/token' imported from /workspace/ywi-nextjs/lib/auth.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a2202cd883279637cf69667c7f73